### PR TITLE
fix panic from nil msg dereference

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -35,7 +35,11 @@ func (c *Cache) ServeDNS(ctx context.Context, w MessageWriter, r *Query) {
 	}
 
 	msg, err := w.Recur(ctx)
-	if err == nil && msg.RCode == NoError {
+	if err != nil || msg == nil {
+		w.Status(ServFail)
+		return
+	}
+	if msg.RCode == NoError {
 		c.insert(msg, now)
 	}
 	writeMessage(w, msg)


### PR DESCRIPTION
Hi @benburkert,

We found this library earlier this week and were excited to try it as a caching `Resolver` replacement in our service. Not long after we deployed a test, we got a panic from a nil dereference and traced it to `cache.go:41`, which doesn’t nil check `msg`.

We fixed this bug, but noticed that `ExampleServer_recursiveWithZone` fails the build with a chan read deadlock. We tried to implement a fix, but honestly couldn’t unravel the `recurc` / `replyc` logic in the couple hours we spent on it.

What’s the plan for this library? The code and test quality seem pretty high quality.