### PR TITLE
Synced with BenBurkert/DNS - Enables recursive DNS lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,49 @@
 # dns [![GoDoc](https://godoc.org/github.com/benburkert/dns?status.svg)](https://godoc.org/github.com/benburkert/dns) [![Build Status](https://travis-ci.org/benburkert/dns.svg)](https://travis-ci.org/benburkert/dns) [![Go Report Card](https://goreportcard.com/badge/github.com/benburkert/dns)](https://goreportcard.com/report/github.com/benburkert/dns)
 
 DNS client and server package. [See godoc for details & examples.](https://godoc.org/github.com/benburkert/dns)
+
+This fork adds a new Upstream() method to allow a caller to call a random DNS server selected from alternates (if any were provided).
+
+### Example Usage:
+
+```
+	client := new(dns.Client)
+
+	client.Transport = &dns.Transport{
+		Proxy: dns.NameServers{
+			&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53},
+			&net.UDPAddr{IP: net.IPv4(8, 8, 4, 4), Port: 53},
+		}.Upstream(rand.Reader),
+	}
+
+	// This is the http/s dialer
+	dialer := &net.Dialer{
+		Resolver: &net.Resolver{
+			PreferGo: true,
+
+			Dial: client.Dial,
+		},
+	}
+
+  // Set a key telling us to select an alternate DNS server (8.8.4.4 in this case).
+	ctx := context.Background()
+	ctxupstream := context.WithValue(ctx, dns.UpstreamKey, 0)
+
+	conn, err := dialer.DialContext(ctxupstream, "tcp", "example.com:80")
+
+	if err != nil {
+		t.Errorf("Error connecting to site: %s\n", err)
+	}
+  
+	fmt.Fprintf(conn, "GET / HTTP/1.0\r\n\r\n")
+	_, err = bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Errorf("Error reading http stream from site: %s\n", err)
+	}
+  
+	fmt.Printf("Success - Upstream DNS request for xaxis.com returned: %s\n", conn.RemoteAddr().String())
+
+	conn.Close()
+  ```
+
+

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync/atomic"
+	//"fmt"
 )
 
 // Client is a DNS client.
@@ -28,7 +29,6 @@ func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, e
 		if err != nil {
 			return nil, err
 		}
-
 		conn, err := c.dial(ctx, addr)
 		if err != nil {
 			return nil, err
@@ -48,7 +48,6 @@ func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, e
 		if err != nil {
 			return nil, err
 		}
-
 		conn, err := c.dial(ctx, addr)
 		if err != nil {
 			return nil, err

--- a/client.go
+++ b/client.go
@@ -23,6 +23,7 @@ type Client struct {
 // Dial dials a DNS server and returns a net Conn that reads and writes DNS
 // messages.
 func (c *Client) Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	//fmt.Println("[DEBUG] client.go - ctx", ctx)
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 		addr, err := net.ResolveTCPAddr(network, address)

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/benburkert/dns"
+	"github.com/winstonprivacyinc/dns"
 )
 
 func ExampleClient_overrideNameServers() {

--- a/init/init.go
+++ b/init/init.go
@@ -8,7 +8,7 @@ package init
 import (
 	"net"
 
-	"github.com/benburkert/dns"
+	"github.com/winstonprivacyinc/dns"
 )
 
 func init() {

--- a/nameservers.go
+++ b/nameservers.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net"
 	"sync/atomic"
+	//"fmt"
 )
 
 // NameServers is a slice of DNS nameserver addresses.
@@ -63,5 +64,12 @@ func (s NameServers) Upstream(rand io.Reader) ProxyFunc {
 
 		//fmt.Printf("  *** DNS.Upstream() - FOUND KEY %d %s\n", idx.Uint64() + 1, s[idx.Uint64() + 1].String())
 		return s[idx.Uint64() + 1], nil
+	}
+}
+
+// RLS 8/10/2018 - Returns first entry
+func (s NameServers) First() ProxyFunc {
+	return func(ctx context.Context, _ net.Addr) (net.Addr, error) {
+		return s[0], nil
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -115,7 +115,8 @@ func (t *Transport) dial(ctx context.Context, addr net.Addr) (net.Conn, bool, er
 
 	conn, err := dial(ctx, network, addr.String())
 	if err != nil {
-		fmt.Printf("[DEBUG] dns dial - err 2: %v\n", err)
+		// operation was canceled -> the caller aborted the connection, typically by closing a browser tab.
+		//fmt.Printf("[DEBUG] dns dial - err 2: %s %s %v\n", network, addr.String(), err)
 		return nil, false, err
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"fmt"
 )
 
 // Transport is an implementation of AddrDialer that manages connections to DNS
@@ -97,6 +98,7 @@ func (t *Transport) dial(ctx context.Context, addr net.Addr) (net.Conn, bool, er
 	if t.Proxy != nil {
 		var err error
 		if addr, err = t.Proxy(ctx, addr); err != nil {
+			fmt.Printf("[DEBUG] dns dial - err: %v\n", err)
 			return nil, false, err
 		}
 	}
@@ -113,6 +115,7 @@ func (t *Transport) dial(ctx context.Context, addr net.Addr) (net.Conn, bool, er
 
 	conn, err := dial(ctx, network, addr.String())
 	if err != nil {
+		fmt.Printf("[DEBUG] dns dial - err 2: %v\n", err)
 		return nil, false, err
 	}
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benburkert/dns/internal/must"
+	"github.com/winstonprivacyinc/dns/internal/must"
 )
 
 var transportTests = []struct {


### PR DESCRIPTION
The old DNS client did not perform recursive DNS lookups so many sites (most notably, Microsoft) could not be connected to because we couldn't resolve their domain names. This update brings us up to date and resolves this.